### PR TITLE
Refactor: Add cache for getting the price using ConcurrenDictionary

### DIFF
--- a/LegacyOrderService/Features/System/RefreshCacheProductPriceCommand.cs
+++ b/LegacyOrderService/Features/System/RefreshCacheProductPriceCommand.cs
@@ -1,0 +1,44 @@
+﻿using LegacyOrderService.Data.Entities;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LegacyOrderService.Features.System;
+
+public class RefreshCacheProductPriceCommand: IRequest
+{
+    public class RefreshCacheProductPriceCommandHandler : IRequestHandler<RefreshCacheProductPriceCommand>
+    {
+        private readonly OrderDbContext _orderDbContext;
+
+        public RefreshCacheProductPriceCommandHandler(OrderDbContext orderDbContext)
+        {
+            _orderDbContext = orderDbContext;
+        }
+
+        public async Task Handle(RefreshCacheProductPriceCommand command, CancellationToken cancellationToken)
+        {
+            //it is only mock data
+
+            //On the production it should get data from DB instead of this and the key should be Id instead of name of product
+            //every step related to create, update, delete product also change the price, it should call this command to update newest data for the cache
+
+             Dictionary<string, double> _productPrices = new()
+            {
+                ["Widget"] = 12.99,
+                ["Gadget"] = 15.49,
+                ["Doohickey"] = 8.75
+            };
+
+            Program.PriceOfProducts.Clear();
+
+            foreach (var item in _productPrices)
+            {
+                Program.PriceOfProducts.TryAdd(item.Key, item.Value);
+            }
+        }
+    }
+}

--- a/LegacyOrderService/LegacyOrderService.csproj
+++ b/LegacyOrderService/LegacyOrderService.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LegacyOrderService/Program.cs
+++ b/LegacyOrderService/Program.cs
@@ -1,13 +1,13 @@
-using LegacyOrderService.Config.Exceptions;
 using LegacyOrderService.Data.Entities;
+using LegacyOrderService.Features.System;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 
-//PRepare everything before start the application
-
+//Prepare everything before start the application
 
 var services = new ServiceCollection();
 
@@ -18,5 +18,29 @@ services.AddMediatR(cfg =>
 {
     cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
 });
+
+PriceOfProducts = new ConcurrentDictionary<string, double>();
+ServiceProvider = services.BuildServiceProvider();
+
+
+await InitCacheForPriceProduct();
+
+
+public partial class Program
+{
+    public static ConcurrentDictionary<string, double> PriceOfProducts { get; set; }
+    public static IServiceProvider ServiceProvider { get; set; }
+
+
+    public static async Task InitCacheForPriceProduct()
+    {
+        //Init cache for price of product
+        using var scope = Program.ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await mediator.Send(new RefreshCacheProductPriceCommand());
+    }
+
+}
 
 


### PR DESCRIPTION
In the legacy old project is using Dictionary but it can lead the problem related to multiple process from UI come to the system, it can not share the resource anymore because it is on the another process.
Instead of this, use ConcurrentDictionary (Represents a thread-safe collection of keys and values also may be used concurrently from multiple threads)

Currently the data for prices it is only mock data
On the production it should get data from DB instead of this and the key should be Id instead of name of product
Every step related to create, update, delete product also change the price, it should call this command to update newest data for the cache

More technical: Add ServiceProvider as static we can inject all service every where that we want instead of initial it from constructor