### PR TITLE
Refactor and Fix bug: Add in memory queue by using Channel, Add order command, optimization for create order workflow, validate order input

### DIFF
--- a/LegacyOrderService/Config/Exceptions/Exceptions.cs
+++ b/LegacyOrderService/Config/Exceptions/Exceptions.cs
@@ -5,7 +5,9 @@ namespace LegacyOrderService.Config.Exceptions;
 public static class Exceptions
 {
     public static DomainException ProductIdIsRequired = new DomainException("ProjectId is required");
-    public static DomainException ProductNameIsRequired = new DomainException("ProductName is required");
+    public static DomainException ProductNameIsRequired = new DomainException("Product name is required");
+    public static DomainException CustomerNameIsRequired = new DomainException("Customer name is required");
+    public static DomainException QuantityMustBeGreaterThenZero = new DomainException("Product does not exist");
 
     public static DomainException AppendMessage(this DomainException exception, string message)
     {

--- a/LegacyOrderService/Data/Entities/Order.cs
+++ b/LegacyOrderService/Data/Entities/Order.cs
@@ -10,7 +10,6 @@ namespace LegacyOrderService.Data.Entities;
 
 public class Order
 {
-    public string Id { get; set; }
     public string CustomerName;
     public string ProductName;
     public int Quantity;
@@ -23,11 +22,6 @@ public class Order
         public void Configure(EntityTypeBuilder<Order> builder)
         {
             builder.ToTable(TABLE_NAME);
-
-            builder.HasKey(e => e.Id);
-            builder.Property(e => e.Id);
-
-            builder.Property(e => e.Id).HasMaxLength(100);
 
         }
     }

--- a/LegacyOrderService/Data/Entities/Order.cs
+++ b/LegacyOrderService/Data/Entities/Order.cs
@@ -10,6 +10,7 @@ namespace LegacyOrderService.Data.Entities;
 
 public class Order
 {
+    public int Id { get; set; }
     public string CustomerName;
     public string ProductName;
     public int Quantity;
@@ -22,6 +23,7 @@ public class Order
         public void Configure(EntityTypeBuilder<Order> builder)
         {
             builder.ToTable(TABLE_NAME);
+            builder.HasKey(e => e.Id);
 
         }
     }

--- a/LegacyOrderService/Features/Event/EventCreateOrderCommand.cs
+++ b/LegacyOrderService/Features/Event/EventCreateOrderCommand.cs
@@ -30,7 +30,7 @@ public class EventCreateOrderCommand : IRequest
                 Price = price
             };
 
-            _orderDbContext.Orders.Add(order);
+            await _orderDbContext.Orders.AddAsync(order);
             await _orderDbContext.SaveChangesAsync(cancellationToken);
         }
     }

--- a/LegacyOrderService/Features/Event/EventCreateOrderCommand.cs
+++ b/LegacyOrderService/Features/Event/EventCreateOrderCommand.cs
@@ -1,0 +1,37 @@
+﻿using LegacyOrderService.Data.Entities;
+using MediatR;
+
+public class EventCreateOrderCommand : IRequest
+{
+    public string CustomerName { get; set; } = default!;
+    public string ProductName { get; set; } = default!;
+    public int Quantity { get; set; }
+
+    public class EventCreateOrderCommandHandler : IRequestHandler<EventCreateOrderCommand>
+    {
+        private readonly OrderDbContext _orderDbContext;
+
+        public EventCreateOrderCommandHandler(OrderDbContext orderDbContext)
+        {
+            _orderDbContext = orderDbContext;
+        }
+
+        public async Task Handle(EventCreateOrderCommand request, CancellationToken cancellationToken)
+        {
+
+            //get price from cache
+            Program.PriceOfProducts.TryGetValue(request.ProductName, out double price);
+
+            var order = new Order
+            {
+                CustomerName = request.CustomerName,
+                ProductName = request.ProductName,
+                Quantity = request.Quantity,
+                Price = price
+            };
+
+            _orderDbContext.Orders.Add(order);
+            await _orderDbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/LegacyOrderService/Features/Order/CreateOrderCommand.cs
+++ b/LegacyOrderService/Features/Order/CreateOrderCommand.cs
@@ -1,0 +1,53 @@
+﻿using LegacyOrderService.Config.Exceptions;
+using LegacyOrderService.Data.Entities;
+using LegacyOrderService.Helpers;
+using MediatR;
+using System;
+
+namespace LegacyOrderService.Features;
+
+public class CreateOrderCommand : IRequest<string>
+{
+    public string CustomerName { get; set; } = default!;
+    public string ProductName { get; set; } = default!;
+    public int Quantity { get; set; }
+
+
+    public class CreateOrderCommandHandler : IRequestHandler<CreateOrderCommand, string>
+    {
+        private readonly OrderDbContext _orderDbContext;
+        private readonly IMediator _mediator;
+
+        public CreateOrderCommandHandler(OrderDbContext orderDbContext, IMediator mediator)
+        {
+            _orderDbContext = orderDbContext;
+            _mediator = mediator;
+        }
+
+        public async Task<string> Handle(CreateOrderCommand command, CancellationToken cancellationToken)
+        {
+
+            //validate data
+            command.ProductName.IsEmpty().ThenThrow(Exceptions.ProductNameIsRequired);
+
+            command.CustomerName.IsEmpty().ThenThrow(Exceptions.CustomerNameIsRequired);
+
+            (command.Quantity <= 0).ThenThrow(Exceptions.QuantityMustBeGreaterThenZero);
+
+            (!Program.PriceOfProducts.ContainsKey(command.ProductName)).ThenThrow(Exceptions.QuantityMustBeGreaterThenZero);
+
+            //push message to queue
+            await Program.OrderEventChannel.Writer.WriteAsync(new EventCreateOrderCommand()
+            {
+                CustomerName = command.CustomerName,
+                ProductName = command.ProductName,
+                Quantity = command.Quantity,
+            });
+
+            Console.WriteLine("✅ Order queued. Will be processed shortly...");
+
+            return "";
+
+        }
+    }
+}

--- a/LegacyOrderService/Features/Test/TestOrderCommand.cs
+++ b/LegacyOrderService/Features/Test/TestOrderCommand.cs
@@ -1,0 +1,48 @@
+﻿using LegacyOrderService.Config.Exceptions;
+using LegacyOrderService.Data.Entities;
+using LegacyOrderService.Helpers;
+using MediatR;
+using System;
+
+namespace LegacyOrderService.Features;
+
+public class TestOrderCommand : IRequest
+{
+
+
+    public class CreateOrderCommandHandler : IRequestHandler<TestOrderCommand>
+    {
+        private readonly IMediator _mediator;
+
+        public CreateOrderCommandHandler(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        public async Task Handle(TestOrderCommand command, CancellationToken cancellationToken)
+        {
+            Console.WriteLine("Enter customer name:");
+            var name = Console.ReadLine();
+
+            Console.WriteLine("Enter product name:");
+            var product = Console.ReadLine();
+
+            Console.WriteLine("Enter quantity:");
+            if (!int.TryParse(Console.ReadLine(), out var qty))
+            {
+                Console.WriteLine("Invalid quantity!");
+                return;
+            }
+
+            var newOrder = new CreateOrderCommand
+            {
+                CustomerName = name!,
+                ProductName = product!,
+                Quantity = qty
+            };
+
+            await _mediator.Send(newOrder);
+
+        }
+    }
+}

--- a/LegacyOrderService/Helpers/CommonHelper.cs
+++ b/LegacyOrderService/Helpers/CommonHelper.cs
@@ -1,0 +1,44 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace LegacyOrderService.Helpers;
+
+public static class CommonHelper
+{
+    public static bool IsEmpty(this string someString)
+    {
+        return string.IsNullOrEmpty(someString) || string.IsNullOrWhiteSpace(someString);
+    }
+    
+    public static bool HasValue(this string someString)
+    {
+        return !someString.IsEmpty();
+    }
+
+    public static void ThenThrow(this bool value, Exception ex)
+    {
+        if (value)
+        {
+            throw ex;
+        }
+    }
+    
+
+    public static string ToSerializedString(this object obj)
+    {
+        if (obj == default)
+        {
+            return string.Empty;
+        }
+        
+        return JsonSerializer.Serialize(obj);
+    }
+
+    public static string ToMd5Hash(this string someString)
+    {
+        using var md5 = MD5.Create();
+        var result = md5.ComputeHash(Encoding.UTF8.GetBytes(someString));
+        return string.Concat(result.Select(b => b.ToString("X2")));
+    }
+}

--- a/LegacyOrderService/Infrastructure/Queue/EventWorker.cs
+++ b/LegacyOrderService/Infrastructure/Queue/EventWorker.cs
@@ -1,0 +1,58 @@
+﻿using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace LegacyOrderService.Infrastructure.Queue;
+
+public class EventWorker
+{
+    public string Id { get; }
+    private readonly ChannelReader<object> _reader;
+    private CancellationTokenSource? _cts;
+    private Task? _task;
+
+    public EventWorker(string id, ChannelReader<object> reader)
+    {
+        Id = id;
+        _reader = reader;
+
+        StartNew();
+    }
+
+    public void StartNew()
+    {
+        _cts = new CancellationTokenSource();
+        _task = Task.Run(async () =>
+        {
+            while (!_cts.Token.IsCancellationRequested)
+            {
+                var command = await _reader.ReadAsync(_cts.Token);
+
+                if (command is not IRequest)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    using var scope = Program.ServiceProvider.CreateScope();
+                    var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+                    await mediator.Send(command, _cts.Token);
+                }
+                catch (Exception e) when (e is not OperationCanceledException)
+                {
+                    Console.WriteLine(e);
+                }
+            }
+
+            _cts.Token.ThrowIfCancellationRequested();
+        });
+    }
+
+}

--- a/LegacyOrderService/LegacyOrderService.csproj
+++ b/LegacyOrderService/LegacyOrderService.csproj
@@ -30,8 +30,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Features\Order\" />
-  </ItemGroup>
-
 </Project>

--- a/LegacyOrderService/Program.cs
+++ b/LegacyOrderService/Program.cs
@@ -1,36 +1,58 @@
-using LegacyOrderService.Data.Entities;
+﻿using LegacyOrderService.Data.Entities;
+using LegacyOrderService.Features;
 using LegacyOrderService.Features.System;
+using LegacyOrderService.Infrastructure.Queue;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Threading.Channels;
 
-
-//Prepare everything before start the application
-
-var services = new ServiceCollection();
-
-services.AddDbContext<OrderDbContext>(opt =>
-    opt.UseSqlite(@"Data Source=Data\orders.db"));
-
-services.AddMediatR(cfg =>
-{
-    cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
-});
-
-PriceOfProducts = new ConcurrentDictionary<string, double>();
-ServiceProvider = services.BuildServiceProvider();
-
-
-await InitCacheForPriceProduct();
-
-
-public partial class Program
+public class Program
 {
     public static ConcurrentDictionary<string, double> PriceOfProducts { get; set; }
     public static IServiceProvider ServiceProvider { get; set; }
+    public static Channel<object> OrderEventChannel { get; set; } = Channel.CreateUnbounded<object>();
+    public static List<EventWorker> OrderEventWorkers { get; set; } = new();
 
+    public static async Task Main(string[] args)
+    {
+        var builder = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
+    {
+
+        services.AddDbContext<OrderDbContext>(opt =>
+            opt.UseSqlite(@"Data Source=Data\orders.db"));
+
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+        });
+
+        ServiceProvider = services.BuildServiceProvider();
+
+
+    })
+    .Build();
+
+
+        PriceOfProducts = new ConcurrentDictionary<string, double>();
+
+        await InitCacheForPriceProduct();
+        InitiateMemoryQueue();
+
+        //Start Test here
+        using var scope = ServiceProvider.CreateScope();
+        var _mediatR = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await _mediatR.Send(new TestOrderCommand());
+
+        builder.Run();
+
+
+    }
 
     public static async Task InitCacheForPriceProduct()
     {
@@ -41,6 +63,14 @@ public partial class Program
         await mediator.Send(new RefreshCacheProductPriceCommand());
     }
 
+    public static void InitiateMemoryQueue()
+    {
+        OrderEventWorkers = Enumerable.Range(1, 10)
+            .Select(i => new EventWorker(i.ToString(), OrderEventChannel.Reader)).ToList();
+    }
+
 }
+
+
 
 


### PR DESCRIPTION
Use Channel for queue the message for:
+ Decoupled command execution
+ Non-blocking UI
+ Scalable
+ Easy to change or alternate by others message broker queue like RabbitMQ/Kafka
+ Present event-driven architecture

Currently I have just Initialed 10 consumers to handle the message of EventCreateOrder on Channel queue, number of consumer can up or down the size, it really depends on how big and how far our system can go.

